### PR TITLE
Update regressby.ado

### DIFF
--- a/regressby.ado
+++ b/regressby.ado
@@ -87,7 +87,7 @@ program define regressby
 			tempvar `var'N
 			encode `var', gen(``var'N')
 			local bynumeric `bynumeric' ``var'N'
-			local bystr `var'  // list of string by-vars
+			local bystr `bystr' `var'  // list of string by-vars
 		}
 	}
 	


### PR DESCRIPTION
Thanks for the command — it is super useful. When one groups by multiple string variables, only the last one appears in the dataset. This PR corrects this behavior.